### PR TITLE
Second implement (Enable to work!)

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,9 @@ const parseList = (listNode) => {
         case "IMG":
           str += node.title;
           break;
+        case "A":
+          str += node.innerText;
+          break;
         case "#text":
           if (node.nodeValue === "\n") {
             break;

--- a/index.js
+++ b/index.js
@@ -1,20 +1,22 @@
 /**
- * @param {Node} ul 選択範囲の unordered list
+ * @param {Node} ul or ol 選択範囲の unordered list もしくは orderd list
  * @return {string} Markdown っぽくなった文字列
  */
 const parseList = (listNode) => {
+  // 選択範囲が ul or ol でない時に for 文で回そうとするとエラーになるので、その場合は return する
+  validListNodeNames = ["UL", "OL"];
+  if (!validListNodeNames.includes(listNode.nodeName)) {
+    return;
+  }
+
   const indent = `${"\b".repeat(4)}`;
   const bulletListMaker = "•";
   let ary = [];
 
-  // 選択範囲が ul でない時に for 文で回そうとするとエラーになるので、その場合は return する
-  if (listNode.nodeName !== "UL") {
-    return;
-  }
-
-  for (const child of listNode.children) {
+  // listNode(ul or ol) の children として listItem(li) を想定している
+  for (const listItem of listNode.children) {
     let str = "";
-    for (let node of child.childNodes) {
+    for (let node of listItem.childNodes) {
       switch (node.nodeName) {
         // ネストしたリストであれば、 parseList() を再帰的に呼ぶ
         case "UL":

--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ const parseList = (listNode, nestedCount = 0) => {
           if (node.nodeValue === "\n") {
             break;
           }
-          str += node.nodeValue;
+          // ネストしたリスト内に複数の要素があると text の末尾に改行("\n")が余分についてしまうので、trim() している
+          str += node.nodeValue.trim();
           break;
         default:
           break;

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const parseList = (listNode) => {
           str += node.title;
           break;
         case "A":
+        case "CODE":
           str += node.innerText;
           break;
         case "#text":

--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@
  * @param {Node} ul or ol 選択範囲の unordered list もしくは orderd list
  * @return {string} Markdown っぽくなった文字列
  */
-const parseList = (listNode) => {
+const parseList = (listNode, nestedCount = 0) => {
   // 選択範囲が ul or ol でない時に for 文で回そうとするとエラーになるので、その場合は return する
   validListNodeNames = ["UL", "OL"];
   if (!validListNodeNames.includes(listNode.nodeName)) {
     return;
   }
 
-  const indent = `${"\b".repeat(4)}`;
+  const defaultIndent = "\b".repeat(4);
   const bulletListMaker = "•";
   let ary = [];
 
@@ -20,7 +20,7 @@ const parseList = (listNode) => {
       switch (node.nodeName) {
         // ネストしたリストであれば、 parseList() を再帰的に呼ぶ
         case "UL":
-          str += `\n${indent}${parseList(node)}`;
+          str += `\n${parseList(node, nestedCount + 1)}`;
           break;
         case "IMG":
           str += node.title;
@@ -39,7 +39,9 @@ const parseList = (listNode) => {
           break;
       }
     }
-    ary.push(`${bulletListMaker} ${str}`);
+    // nestedCount が 0 であれば、indent はつかない
+    const indent = defaultIndent.repeat(nestedCount);
+    ary.push(`${indent}${bulletListMaker} ${str}`);
   }
   return ary.join("\n");
 };


### PR DESCRIPTION
## Why

#1 の続き

## How

- link（aタグ）の対応
- orderd list（ol）の対応
- code タグの対応
- ネストしたリストの二つ目以降がインデントされてない、の対応
- ネストしたリスト内に複数の要素があると変な改行が入る、の対応

<img width="1276" alt="日報_2020_05_12__火__daido1976__kininaru__-_feedforce_esa_io" src="https://user-images.githubusercontent.com/35087200/82131745-697fb880-9813-11ea-8f2f-9d0704e821dc.png">

## 参考

- https://stackoverflow.com/questions/35213147/difference-between-textcontent-vs-innertext
- https://developer.mozilla.org/ja/docs/Web/API/Node/textContent#Differences_from_innerText
- [JavaScriptにおける配列の空要素除去filterパターン](https://qiita.com/akameco/items/1636e0448e81e17e3646)
    - 結局使わなかったけど `arr.filter(v => v)` で falsy な要素を除去できる